### PR TITLE
Fix for https://github.com/stdunbar/jisql/issues/1: CSV formatter should not hardcode us-ascii encoding.

### DIFF
--- a/src/main/java/com/xigole/util/sql/outputformatter/CSVFormatter.java
+++ b/src/main/java/com/xigole/util/sql/outputformatter/CSVFormatter.java
@@ -109,7 +109,7 @@ public class CSVFormatter implements JisqlFormatter {
      */
     public void formatData( PrintStream out, ResultSet resultSet, ResultSetMetaData metaData ) throws Exception {
     	
-    	CsvWriter csvWriter = new CsvWriter( out, delimiter, Charset.forName( "us-ascii" )  );
+    	CsvWriter csvWriter = new CsvWriter( out, delimiter, Charset.defaultCharset() );
     	
         while( resultSet.next() ) {
             int numColumns = metaData.getColumnCount();


### PR DESCRIPTION
CSV formatter should not hardcode us-ascii encoding.